### PR TITLE
docs: Apple 公式ドキュメント引用の出典検証と URL 付与

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ IntentTodoWatchApp/         # watchOS アプリ
 - **visionOS**: 空間UI（NavigationSplitView、Ornament、ホバーエフェクト）
 - **ウィジェット**: Small/Medium/Large サイズ対応（Todo一覧表示、アプリ起動は `Link(destination:)` を使用）
 
-> **Widget でのアプリ起動**: Apple公式ドキュメント「Adding interactivity to widgets and Live Activities」に "If you want to offer an interaction that opens the app, use Link" と明記。`Button(intent:)` はアプリを開くだけの用途には非推奨。
+> **Widget でのアプリ起動**: [Adding interactivity to widgets and Live Activities](https://developer.apple.com/documentation/widgetkit/adding-interactivity-to-widgets-and-live-activities) に "An interaction with a button or toggle should do more than open the app. If you want to offer an interaction that opens the app, use `Link` and `widgetURL(_:)`" と明記。アプリを開くだけの用途には `Button(intent:)` より `Link` が公式推奨。
 - **ライブアクティビティ**: Dynamic Island + ロック画面（期限1時間以内で自動表示、`LiveActivityIntent` 使用）
 - **コントロールセンター**: `ControlWidgetButton(action:)` で `LaunchAppIntent` / `.background` Intent を直接呼ぶ
 
@@ -312,7 +312,7 @@ NavigationStack {
 
 ### LiveActivityIntent（Live Activity専用）
 
-Live Activity からアクションを実行する場合は `LiveActivityIntent` を使用する（公式Doc: "make sure it inherits from LiveActivityIntent"）。通常の `AppIntent` ではなく `LiveActivityIntent` を使うことで、Activity の状態操作が可能になる。
+Live Activity からアクションを実行する場合は `LiveActivityIntent` を使用する（[Displaying live data with Live Activities](https://developer.apple.com/documentation/activitykit/displaying-live-data-with-live-activities#Start-and-stop-Live-Activities-from-App-Intents) より "make sure it inherits from `LiveActivityIntent`"）。通常の `AppIntent` ではなく `LiveActivityIntent` を使うことで、Activity の状態操作が可能になる。
 
 ```swift
 struct CompleteTodoFromActivityIntent: LiveActivityIntent {
@@ -329,7 +329,12 @@ struct CompleteTodoFromActivityIntent: LiveActivityIntent {
 }
 ```
 
-**公式Docより**: `LiveActivityIntent` を採用することで、アプリがフォアグラウンドにない状態でも Live Activity を開始可能（"you can only start a Live Activity while the app is in the foreground, unless you adopt App Intents and start the Live Activity using a LiveActivityIntent"）。
+[ActivityKit / Activity](https://developer.apple.com/documentation/activitykit/activity) より: "You can update or end a Live Activity while your app is in the background, but you can only start a Live Activity while the app is in the foreground, unless you adopt App Intents and start the Live Activity using a `LiveActivityIntent`."
+
+さらに [Adding interactivity to widgets and Live Activities](https://developer.apple.com/documentation/widgetkit/adding-interactivity-to-widgets-and-live-activities#Add-an-app-intent-that-performs-the-action) が明記する実行プロセスの差：
+> "If you adopt the `LiveActivityIntent` or `AudioPlaybackIntent` protocol, the system runs the app intent in the app's process. [...] If you adopt the `AppIntent` protocol, add your custom app intent to your widget extension target and your app target."
+
+つまり `LiveActivityIntent` はアプリプロセスで実行、通常の `AppIntent` を Widget 経由で呼ぶ場合は Widget Extension プロセスで実行される。
 
 | Intent種別 | 用途 | 特徴 |
 |-----------|------|------|

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ App Intents 中心設計に基づいたマルチプラットフォーム Todo �
 
 | Extension | 実行パターン | 備考 |
 |:--|:--|:--|
-| **Home Widget** | `Button(intent:)` / `Link(destination:)` | Large Widget の Add Todo は `Button(intent: LaunchAppIntent.addTodo())` で動作確認済み。Apple 公式は単純なアプリ起動なら `Link` を推奨 |
+| **Home Widget** | `Button(intent:)` / `Link(destination:)` | Large Widget の Add Todo は `Button(intent: LaunchAppIntent.addTodo())` で動作確認済み。単純なアプリ起動は `Link` 推奨（[公式ドキュメント](https://developer.apple.com/documentation/widgetkit/adding-interactivity-to-widgets-and-live-activities)）|
 | **Control Center** | `ControlWidgetButton(action:)` | `.foreground(.immediate)` で `LaunchAppIntent`、`.background` で `ToggleUrgentTodoIntent` / `ShowTodoCountIntent` を呼出（`kind` は reverse-domain 形式必須） |
 | **Live Activity** | `Button(intent:)` | `ToggleTodoCompletionIntent` / `SnoozeTodoIntent` が `LiveActivityIntent` 条件付き準拠 |
 | **Siri / Shortcuts** | `AppShortcutsProvider` | Siri フレーズ定義済み |

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -637,7 +637,7 @@ struct ToggleUrgentTodoIntent: AppIntent, ControlConfigurationIntent {
 
 ### LiveActivityIntent の違い
 
-ライブアクティビティからのボタン操作には `LiveActivityIntent` プロトコルが必要です（通常の `AppIntent` では動作しない）。
+ライブアクティビティからのボタン操作には `LiveActivityIntent` プロトコルが必要（[Displaying live data with Live Activities](https://developer.apple.com/documentation/activitykit/displaying-live-data-with-live-activities#Start-and-stop-Live-Activities-from-App-Intents) より "make sure it inherits from `LiveActivityIntent`"）。さらに [Adding interactivity to widgets and Live Activities](https://developer.apple.com/documentation/widgetkit/adding-interactivity-to-widgets-and-live-activities#Add-an-app-intent-that-performs-the-action) によれば `LiveActivityIntent` の `perform()` は**アプリプロセス**で実行される（"the system runs the app intent in the app's process"）。
 
 ```swift
 // ❌ 通常のAppIntentはLiveActivityで動作しない

--- a/docs/insights/04-ui-integration.md
+++ b/docs/insights/04-ui-integration.md
@@ -75,7 +75,7 @@ NavigationStack {
 
 ### 実行順序
 
-公式ドキュメントによると:
+[onAppIntentExecution 公式ドキュメント](https://developer.apple.com/documentation/SwiftUI/View/onAppIntentExecution(_:perform:)) の挙動記述によると:
 > "If the app intent implements a perform() method, it will be called after the action closure."
 
 つまり `onAppIntentExecution` のクロージャが**先**に実行され、その後に Intent の `perform()` が呼ばれる。両方でナビゲーションを行うと二重実行になるため、どちらか一方に統一することを推奨。

--- a/docs/insights/05-extensions-and-data-sharing.md
+++ b/docs/insights/05-extensions-and-data-sharing.md
@@ -126,7 +126,8 @@ Widget Extension の `Button(intent:)` や `ControlWidgetButton(action:)` から
 
 アプリ起動が目的の場合は `Link(destination:)` を優先する。
 
-> "If you want to offer an interaction that opens the app, use Link" — Apple 公式ドキュメント「Adding interactivity to widgets and Live Activities」
+> "An interaction with a button or toggle should do more than open the app. If you want to offer an interaction that opens the app, use `Link` and `widgetURL(_:)`"
+> — [Adding interactivity to widgets and Live Activities](https://developer.apple.com/documentation/widgetkit/adding-interactivity-to-widgets-and-live-activities)
 
 ---
 

--- a/docs/insights/06-control-widget-ios26.md
+++ b/docs/insights/06-control-widget-ios26.md
@@ -23,7 +23,7 @@
 
 ### ControlWidgetButton + foreground Intent
 
-Control Widget からアプリを開く場合、`ControlWidgetButton(action:)` に `.foreground(.immediate)` の Intent を渡す。**`kind` は Extension Bundle ID 形式（reverse-domain）で書く**のが重要。
+Control Widget からアプリを開く場合、`ControlWidgetButton(action:)` に `.foreground(.immediate)` の Intent を渡す。
 
 ```swift
 struct QuickAddTodoControl: ControlWidget {
@@ -41,15 +41,13 @@ struct QuickAddTodoControl: ControlWidget {
 }
 ```
 
-Apple 公式サンプル（"Adding refinements and configuration to controls"）も reverse-domain 形式：
+**`kind` は reverse-domain 形式を推奨**。Apple 公式の全サンプル（[Creating controls to perform actions across the system](https://developer.apple.com/documentation/widgetkit/creating-controls-to-perform-actions-across-the-system)）が `com.example.MyApp.TimerToggle` / `com.example.myApp.performActionButton` / `com.yourcompany.GarageDoorOpener` 等の reverse-domain 形式を使用：
 
 ```swift
 static let kind: String = "com.example.MyApp.TimerToggle"
 ```
 
-### 短い kind の失敗
-
-`static let kind = "QuickAddTodoControl"` のような**短い名前は機能しない**（少なくとも iOS 26 初期）。`ControlWidgetButton` の foreground 遷移が起動しない。
+本プロジェクトで過去に `"QuickAddTodoControl"` のような短い名前にしていた時期は foreground 遷移が機能しなかった（経験則）。公式は形式を明示していないが、サンプルに合わせて reverse-domain 形式にしておくのが無難。
 
 ### ControlConfigurationIntent と SetValueIntent
 

--- a/docs/insights/07-platform-specific.md
+++ b/docs/insights/07-platform-specific.md
@@ -45,34 +45,26 @@ IntentTodoWatchApp/
 
 ### LiveActivityIntent vs AppIntent
 
-Live Activity からアクションを実行する場合は `LiveActivityIntent` を使用する（公式Doc: "make sure it inherits from LiveActivityIntent"）。
+Live Activity から Activity の開始/更新/終了を伴うアクションを実行する場合は `LiveActivityIntent` を使用する（[Displaying live data with Live Activities](https://developer.apple.com/documentation/activitykit/displaying-live-data-with-live-activities#Start-and-stop-Live-Activities-from-App-Intents) より "When you implement your app intent that starts the Live Activity, make sure it inherits from `LiveActivityIntent`."）。
 
-**重要**: `LiveActivityIntent` を採用することで、アプリがフォアグラウンドにない状態でも Live Activity を開始可能。公式ドキュメントには以下の記載がある:
-> "you can only start a Live Activity while the app is in the foreground, unless you adopt App Intents and start the Live Activity using a LiveActivityIntent"
+**重要な挙動差**（[ActivityKit / Activity](https://developer.apple.com/documentation/activitykit/activity) および [Adding interactivity to widgets and Live Activities](https://developer.apple.com/documentation/widgetkit/adding-interactivity-to-widgets-and-live-activities#Add-an-app-intent-that-performs-the-action) より）:
 
-```swift
-struct CompleteTodoFromActivityIntent: LiveActivityIntent {
-    static var title: LocalizedStringResource = "Complete Todo"
+- Live Activity の**開始**はアプリがフォアグラウンドにある時のみ可能。ただし `LiveActivityIntent` を使えばバックグラウンドからも可能:
+  > "You can update or end a Live Activity while your app is in the background, but you can only start a Live Activity while the app is in the foreground, unless you adopt App Intents and start the Live Activity using a `LiveActivityIntent`."
+- `LiveActivityIntent` の `perform()` は**アプリプロセス**で実行される:
+  > "If you adopt the `LiveActivityIntent` or `AudioPlaybackIntent` protocol, the system runs the app intent in the app's process."
+- 対して通常の `AppIntent` を Widget/Live Activity から呼ぶ場合は **Widget Extension プロセス**で実行される:
+  > "If you adopt the `AppIntent` protocol, add your custom app intent to your widget extension target and your app target."
 
-    @Parameter(title: "Todo ID")
-    var todoId: String
-
-    @MainActor
-    func perform() async throws -> some IntentResult {
-        // Todo完了処理 + Live Activity を終了
-        await endLiveActivity(for: todoId)
-        return .result()
-    }
-}
-```
+本プロジェクトでは `ToggleTodoCompletionIntent` と `SnoozeTodoIntent` を `#if os(iOS)` で `LiveActivityIntent` に条件付き準拠させ、Live Activity のボタン経由でアプリプロセス側で実行されるようにしている。
 
 ### Intent種別の使い分け
 
-| Intent種別 | 用途 | 特徴 |
-|-----------|------|------|
-| `AppIntent` | Siri/Shortcuts/UI | 汎用的なアクション |
-| `LiveActivityIntent` | Dynamic Island/ロック画面 | Activity状態の操作が可能 |
-| `ControlConfigurationIntent` | コントロールセンター | Extension配置必須 |
+| Intent種別 | 用途 | 実行プロセス |
+|-----------|------|------------|
+| `AppIntent` | Siri/Shortcuts/UI/Widget | Siri/Shortcuts はアプリ、Widget は Widget Extension |
+| `LiveActivityIntent` | Dynamic Island/ロック画面（Live Activity ボタン） | アプリプロセス（公式保証） |
+| `ControlConfigurationIntent` | コントロールセンター設定値 | Extension 配置必須 |
 
 ---
 
@@ -143,8 +135,8 @@ Button(intent: OpenAddTodoIntent()) {
 ### 注意点
 
 - `AppIntents`モジュールのimportが必要
-- Intentは`openAppWhenRun = true`でアプリを開くか、バックグラウンド実行
-- **アプリを開くだけの場合は`Link(destination:)`が公式推奨** （Apple Docs: "If you want to offer an interaction that opens the app, use Link"）
+- Intent の実行モード（`supportedModes`）で挙動が決まる（`.background` / `.foreground(.immediate)` 等）
+- **アプリを開くだけが目的の場合は `Link(destination:)` が公式推奨**（[Adding interactivity to widgets and Live Activities](https://developer.apple.com/documentation/widgetkit/adding-interactivity-to-widgets-and-live-activities) より "An interaction with a button or toggle should do more than open the app. If you want to offer an interaction that opens the app, use `Link` and `widgetURL(_:)`"）
 
 ---
 


### PR DESCRIPTION
## Summary

「Apple 公式」と記述している引用について Xcode MCP の DocumentationSearch で一次ソースを検証。全引用の実在を確認し、URL リンクを付与。

## 検証方法

- Xcode MCP `DocumentationSearch` で Apple 公式ドキュメントを検索
- 原文を発見した上でドキュメントに出典リンクを追加

## 検証済み引用

| 引用 | 出典 |
|-----|------|
| "If you want to offer an interaction that opens the app, use Link" | [Adding interactivity to widgets and Live Activities](https://developer.apple.com/documentation/widgetkit/adding-interactivity-to-widgets-and-live-activities) ✅ |
| "make sure it inherits from LiveActivityIntent" | [Displaying live data with Live Activities](https://developer.apple.com/documentation/activitykit/displaying-live-data-with-live-activities#Start-and-stop-Live-Activities-from-App-Intents) ✅ |
| "you can only start a Live Activity while the app is in the foreground, unless you adopt App Intents and start the Live Activity using a LiveActivityIntent" | [ActivityKit / Activity](https://developer.apple.com/documentation/activitykit/activity) ✅ |
| "Creates a button template for a control that launches an app" (OpenIntent 制約 initializer) | [ControlWidgetButton.init(action:label:)](https://developer.apple.com/documentation/widgetkit/controlwidgetbutton/init(action:label:)-8oxxp) ✅ |
| kind の reverse-domain 形式 (サンプル全部この形式) | [Creating controls to perform actions across the system](https://developer.apple.com/documentation/widgetkit/creating-controls-to-perform-actions-across-the-system) ✅ |

## 新規追記

Apple 公式が我々の経験則（実行プロセスとDI 登録先の関係）を直接裏付ける記述を発見：

> "If you adopt the `LiveActivityIntent` or `AudioPlaybackIntent` protocol, the system runs the app intent in the app's process. [...] If you adopt the `AppIntent` protocol, add your custom app intent to your widget extension target and your app target."

— [Adding interactivity to widgets and Live Activities](https://developer.apple.com/documentation/widgetkit/adding-interactivity-to-widgets-and-live-activities#Add-an-app-intent-that-performs-the-action)

これを CLAUDE.md / docs/insights/07 に反映。

## 訂正

- docs/insights/06 の「短い kind では動かない」→ 「本プロジェクト経験則」とトーン調整。公式は形式を明示していないが、全サンプルが reverse-domain である。

## Test plan

- [x] ビルド成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)