### PR TITLE
docs: continueInForeground 不動作の記述を訂正（未検証扱いに）

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -164,7 +164,7 @@ func suggestEmoji(for todoTitle: String) async throws -> String {
 - `LaunchAppIntent`: `[.foreground(.immediate)]` — 起点から即時フォアグラウンド
 - `ToggleTodoCompletionIntent` / `DeleteTodoIntent` / `ToggleFavoriteIntent` / `ToggleUrgentTodoIntent` / `ShowTodoCountIntent`: `.background`
 
-> **経験則 (実機検証)**: Control Widget コンテキストで `continueInForeground()` を呼んでもアプリが開かない。Shortcuts / Siri 経由では動作する。Apple 公式には明示的な記述は確認できていない。
+> **未検証**: Control Widget からの `continueInForeground()` 呼び出しは現状未検証。かつて失敗していた記録があるが、それは `IntentTodoAppIntentsPackage` 重複 Bug 下での話で、fix 後は再検証していない。
 
 ### AppDependencyManager + @Dependency + perform() による Intent → UI 連携 ✅ 実装済み
 

--- a/docs/insights/03-app-intents-core.md
+++ b/docs/insights/03-app-intents-core.md
@@ -272,7 +272,7 @@ func perform() async throws -> some IntentResult {
 }
 ```
 
-> **Note**: `continueInForeground()` はControl Widgetコンテキストでは動作しない。Shortcuts/Siri経由での使用を想定。
+> **Note**: Control Widget からの `continueInForeground()` 呼び出しは現時点で未検証（かつて動作しないと記録していたが、当時の失敗は `IntentTodoAppIntentsPackage` 重複 Bug によるもので、fix 後は未検証）。
 
 ---
 


### PR DESCRIPTION
continueInForeground が Control Widget から動かないとの記述は IntentTodoAppIntentsPackage 重複 Bug 下での観測に基づくもので、fix 後は未検証。経験則ではなく未検証扱いに修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)