### PR TITLE
refactor: App Intent を Primary + FromExtension に分離、共通ロジック抽出

### DIFF
--- a/IntentTodoLiveActivity/TodoLiveActivity.swift
+++ b/IntentTodoLiveActivity/TodoLiveActivity.swift
@@ -52,13 +52,13 @@ struct TodoDeadlineLiveActivity: Widget {
                         dueDate: context.state.dueDate
                     )
                     HStack(spacing: 16) {
-                        Button(intent: ToggleTodoCompletionIntent(todo: entity)) {
+                        Button(intent: ToggleTodoCompletionFromExtensionIntent(todo: entity)) {
                             Label("Complete", systemImage: "checkmark.circle.fill")
                         }
                         .buttonStyle(.borderedProminent)
                         .tint(.green)
 
-                        Button(intent: SnoozeTodoIntent(todo: entity)) {
+                        Button(intent: SnoozeTodoFromExtensionIntent(todo: entity)) {
                             Label("Snooze", systemImage: "clock.arrow.circlepath")
                         }
                         .buttonStyle(.bordered)

--- a/IntentTodoLiveActivity/Views/LockScreenLiveActivityView.swift
+++ b/IntentTodoLiveActivity/Views/LockScreenLiveActivityView.swift
@@ -48,14 +48,14 @@ struct LockScreenLiveActivityView: View {
                 .lineLimit(2)
 
             HStack(spacing: 16) {
-                Button(intent: ToggleTodoCompletionIntent(todo: entity)) {
+                Button(intent: ToggleTodoCompletionFromExtensionIntent(todo: entity)) {
                     Label("Mark Complete", systemImage: "checkmark.circle.fill")
                         .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(.green)
 
-                Button(intent: SnoozeTodoIntent(todo: entity)) {
+                Button(intent: SnoozeTodoFromExtensionIntent(todo: entity)) {
                     Label("Snooze 30m", systemImage: "clock.arrow.circlepath")
                         .frame(maxWidth: .infinity)
                 }

--- a/Packages/TodoAppIntents/Sources/TodoAppIntents/Actions/TodoActions.swift
+++ b/Packages/TodoAppIntents/Sources/TodoAppIntents/Actions/TodoActions.swift
@@ -1,0 +1,122 @@
+//
+//  TodoActions.swift
+//  TodoAppIntents
+//
+//  Shared business logic for todo actions, used by both the Primary (@Dependency-based)
+//  and FromExtension (SharedModelContainer-based) Intent variants.
+//
+//  Each function is @MainActor and operates on a Repository abstraction so the
+//  Intent variants only differ in how they construct the repository.
+//
+
+import Domain
+import Foundation
+import Repository
+
+// MARK: - Result Types
+
+/// Payload returned after toggling a todo's completion.
+@MainActor
+public struct TodoToggleResult: Sendable {
+    public let entity: TodoAppEntity
+    public let isNowCompleted: Bool
+}
+
+/// Payload returned after snoozing a todo.
+@MainActor
+public struct TodoSnoozeResult: Sendable {
+    public let entity: TodoAppEntity
+    public let newDueDate: Date
+    public let title: String
+}
+
+// MARK: - Actions
+
+public enum TodoActions {
+    /// Toggle completion of a specific todo identified by its UUID string.
+    @MainActor
+    public static func toggleCompletion(
+        todoId: String,
+        using repository: any TodoRepositoryProtocol
+    ) throws -> TodoToggleResult {
+        guard let uuid = UUID(uuidString: todoId),
+              let item = try repository.fetch(by: uuid) else {
+            throw IntentError.notFound("Todo not found")
+        }
+        item.isCompleted.toggle()
+        try repository.update(item)
+        return TodoToggleResult(entity: TodoAppEntity(from: item), isNowCompleted: item.isCompleted)
+    }
+
+    /// Toggle favorite status of a specific todo.
+    @MainActor
+    public static func toggleFavorite(
+        todoId: String,
+        using repository: any TodoRepositoryProtocol
+    ) throws -> TodoAppEntity {
+        guard let uuid = UUID(uuidString: todoId),
+              let item = try repository.fetch(by: uuid) else {
+            throw IntentError.notFound("Todo not found")
+        }
+        item.isFavorite.toggle()
+        try repository.update(item)
+        return TodoAppEntity(from: item)
+    }
+
+    /// Delete a specific todo by UUID string.
+    @MainActor
+    public static func delete(
+        todoId: String,
+        using repository: any TodoRepositoryProtocol
+    ) throws {
+        guard let uuid = UUID(uuidString: todoId) else {
+            throw IntentError.validation("Invalid todo ID")
+        }
+        try repository.delete(by: uuid)
+    }
+
+    /// Snooze a todo's due date by the given interval (default: 30 minutes).
+    @MainActor
+    public static func snooze(
+        todoId: String,
+        by interval: TimeInterval = 30 * 60,
+        using repository: any TodoRepositoryProtocol
+    ) throws -> TodoSnoozeResult {
+        guard let uuid = UUID(uuidString: todoId),
+              let item = try repository.fetch(by: uuid),
+              let currentDueDate = item.dueDate else {
+            throw IntentError.notFound("Todo or due date not found")
+        }
+        let newDueDate = currentDueDate.addingTimeInterval(interval)
+        item.dueDate = newDueDate
+        try repository.update(item)
+        return TodoSnoozeResult(
+            entity: TodoAppEntity(from: item),
+            newDueDate: newDueDate,
+            title: item.title
+        )
+    }
+
+    /// Create a new todo.
+    @MainActor
+    public static func create(
+        title: String,
+        todoDescription: String?,
+        dueDate: Date?,
+        isFavorite: Bool,
+        using repository: any TodoRepositoryProtocol
+    ) throws -> TodoAppEntity {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw IntentError.validation("Todo title cannot be empty")
+        }
+        let item = TodoItem(
+            title: trimmed,
+            todoDescription: todoDescription,
+            isFavorite: isFavorite,
+            dueDate: dueDate
+        )
+        try repository.create(item)
+        return TodoAppEntity(from: item)
+    }
+}

--- a/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/AddTodoIntent.swift
+++ b/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/AddTodoIntent.swift
@@ -4,6 +4,7 @@
 //
 
 import AppIntents
+import Domain
 import Repository
 import SwiftData
 
@@ -74,23 +75,15 @@ public struct AddTodoIntent: AppIntent {
 
     @MainActor
     public func perform() async throws -> some IntentResult & ReturnsValue<TodoAppEntity> {
-        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedTitle.isEmpty else {
-            throw IntentError.validation("Todo title cannot be empty")
-        }
-
         let repository = SwiftDataTodoRepository(modelContext: modelContainer.mainContext)
-
-        let todoItem = TodoItem(
-            title: trimmedTitle,
+        let entity = try TodoActions.create(
+            title: title,
             todoDescription: todoDescription,
+            dueDate: dueDate,
             isFavorite: isFavorite,
-            dueDate: dueDate
+            using: repository
         )
-
-        try repository.create(todoItem)
         WidgetReloader.reloadAllWidgets()
-
-        return .result(value: TodoAppEntity(from: todoItem))
+        return .result(value: entity)
     }
 }

--- a/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/DeleteTodoIntent.swift
+++ b/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/DeleteTodoIntent.swift
@@ -4,6 +4,7 @@
 //
 
 import AppIntents
+import Domain
 import Repository
 import SwiftData
 
@@ -40,14 +41,8 @@ public struct DeleteTodoIntent: AppIntent {
     @MainActor
     public func perform() async throws -> some IntentResult {
         let repository = SwiftDataTodoRepository(modelContext: modelContainer.mainContext)
-
-        guard let uuid = UUID(uuidString: todo.id) else {
-            throw IntentError.validation("Invalid todo ID")
-        }
-
-        try repository.delete(by: uuid)
+        try TodoActions.delete(todoId: todo.id, using: repository)
         WidgetReloader.reloadAllWidgets()
-
         return .result()
     }
 }

--- a/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/SnoozeTodoFromExtensionIntent.swift
+++ b/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/SnoozeTodoFromExtensionIntent.swift
@@ -1,0 +1,69 @@
+//
+//  SnoozeTodoFromExtensionIntent.swift
+//  TodoAppIntents
+//
+//  Variant for Live Activity context. Uses SharedModelContainer directly and
+//  conforms to LiveActivityIntent on iOS.
+//
+
+#if os(iOS)
+import ActivityKit
+#endif
+import AppIntents
+import Domain
+import Foundation
+import Repository
+import SwiftData
+
+public struct SnoozeTodoFromExtensionIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Snooze Todo"
+    public static let description = IntentDescription("Internal variant used by Live Activity buttons.")
+    public static let isDiscoverable = false
+    public static let supportedModes: IntentModes = [.background]
+
+    public static var parameterSummary: some ParameterSummary {
+        Summary("Snooze \(\.$todo) by 30 minutes")
+    }
+
+    @Parameter(title: "Todo")
+    public var todo: TodoAppEntity
+
+    public init() {}
+
+    public init(todo: TodoAppEntity) {
+        self.todo = todo
+    }
+
+    @MainActor
+    public func perform() async throws -> some IntentResult & ReturnsValue<TodoAppEntity> {
+        let container = try SharedModelContainer.createContainer()
+        let repository = SwiftDataTodoRepository(modelContext: ModelContext(container))
+        let result = try TodoActions.snooze(todoId: todo.id, using: repository)
+        WidgetReloader.reloadAllWidgets()
+
+        #if os(iOS)
+        await updateMatchingLiveActivity(for: todo.id, newDueDate: result.newDueDate, title: result.title)
+        #endif
+
+        return .result(value: result.entity)
+    }
+
+    #if os(iOS)
+    @MainActor
+    private func updateMatchingLiveActivity(for todoId: String, newDueDate: Date, title: String) async {
+        for activity in Activity<TodoDeadlineActivityAttributes>.activities
+        where activity.attributes.todoId == todoId {
+            let contentState = TodoDeadlineActivityAttributes.ContentState(
+                title: title,
+                dueDate: newDueDate,
+                isCompleted: false
+            )
+            await activity.update(using: contentState)
+        }
+    }
+    #endif
+}
+
+#if os(iOS)
+extension SnoozeTodoFromExtensionIntent: LiveActivityIntent {}
+#endif

--- a/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/SnoozeTodoIntent.swift
+++ b/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/SnoozeTodoIntent.swift
@@ -2,13 +2,10 @@
 //  SnoozeTodoIntent.swift
 //  TodoAppIntents
 //
-//  Extends the due date of a todo by 30 minutes. Also updates any active
-//  Live Activity showing the todo on iOS.
+//  Primary variant: runs in the main app process via @Dependency.
+//  For Live Activity context, use SnoozeTodoFromExtensionIntent.
 //
 
-#if os(iOS)
-import ActivityKit
-#endif
 import AppIntents
 import Domain
 import Repository
@@ -38,41 +35,8 @@ public struct SnoozeTodoIntent: AppIntent {
     @MainActor
     public func perform() async throws -> some IntentResult & ReturnsValue<TodoAppEntity> {
         let repository = SwiftDataTodoRepository(modelContext: modelContainer.mainContext)
-
-        guard let uuid = UUID(uuidString: todo.id),
-              let todoItem = try repository.fetch(by: uuid),
-              let currentDueDate = todoItem.dueDate else {
-            throw IntentError.notFound("Todo or due date not found")
-        }
-
-        let newDueDate = currentDueDate.addingTimeInterval(30 * 60)
-        todoItem.dueDate = newDueDate
-        try repository.update(todoItem)
+        let result = try TodoActions.snooze(todoId: todo.id, using: repository)
         WidgetReloader.reloadAllWidgets()
-
-        #if os(iOS)
-        await updateMatchingLiveActivity(for: todo.id, newDueDate: newDueDate, title: todoItem.title)
-        #endif
-
-        return .result(value: TodoAppEntity(from: todoItem))
+        return .result(value: result.entity)
     }
-
-    #if os(iOS)
-    @MainActor
-    private func updateMatchingLiveActivity(for todoId: String, newDueDate: Date, title: String) async {
-        for activity in Activity<TodoDeadlineActivityAttributes>.activities
-        where activity.attributes.todoId == todoId {
-            let contentState = TodoDeadlineActivityAttributes.ContentState(
-                title: title,
-                dueDate: newDueDate,
-                isCompleted: false
-            )
-            await activity.update(using: contentState)
-        }
-    }
-    #endif
 }
-
-#if os(iOS)
-extension SnoozeTodoIntent: LiveActivityIntent {}
-#endif

--- a/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/ToggleFavoriteIntent.swift
+++ b/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/ToggleFavoriteIntent.swift
@@ -4,6 +4,7 @@
 //
 
 import AppIntents
+import Domain
 import Repository
 import SwiftData
 
@@ -40,16 +41,8 @@ public struct ToggleFavoriteIntent: AppIntent {
     @MainActor
     public func perform() async throws -> some IntentResult & ReturnsValue<TodoAppEntity> {
         let repository = SwiftDataTodoRepository(modelContext: modelContainer.mainContext)
-
-        guard let uuid = UUID(uuidString: todo.id),
-              let todoItem = try repository.fetch(by: uuid) else {
-            throw IntentError.notFound("Todo not found")
-        }
-
-        todoItem.isFavorite.toggle()
-        try repository.update(todoItem)
+        let entity = try TodoActions.toggleFavorite(todoId: todo.id, using: repository)
         WidgetReloader.reloadAllWidgets()
-
-        return .result(value: TodoAppEntity(from: todoItem))
+        return .result(value: entity)
     }
 }

--- a/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/ToggleTodoCompletionFromExtensionIntent.swift
+++ b/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/ToggleTodoCompletionFromExtensionIntent.swift
@@ -1,0 +1,70 @@
+//
+//  ToggleTodoCompletionFromExtensionIntent.swift
+//  TodoAppIntents
+//
+//  Variant for Live Activity / Widget Extension contexts. Does not use @Dependency
+//  because AppDependencyManager registrations may differ per process.
+//  Uses SharedModelContainer (App Group) directly so it works regardless of process.
+//  Also conforms to LiveActivityIntent on iOS so it can drive Dynamic Island / lock screen buttons.
+//
+
+#if os(iOS)
+import ActivityKit
+#endif
+import AppIntents
+import Domain
+import Repository
+import SwiftData
+
+public struct ToggleTodoCompletionFromExtensionIntent: AppIntent {
+    public static var title: LocalizedStringResource { "Toggle Todo Completion" }
+    public static let description = IntentDescription("Internal variant used by Live Activity / Widget buttons.")
+
+    /// Marked as not discoverable so Shortcuts users only see the Primary `ToggleTodoCompletionIntent`.
+    public static let isDiscoverable = false
+
+    public static var supportedModes: IntentModes { .background }
+
+    public static var parameterSummary: some ParameterSummary {
+        Summary("Toggle completion of \(\.$todo)")
+    }
+
+    @Parameter(title: "Todo")
+    public var todo: TodoAppEntity
+
+    public init() {}
+
+    public init(todo: TodoAppEntity) {
+        self.todo = todo
+    }
+
+    @MainActor
+    public func perform() async throws -> some IntentResult & ReturnsValue<TodoAppEntity> {
+        let container = try SharedModelContainer.createContainer()
+        let repository = SwiftDataTodoRepository(modelContext: ModelContext(container))
+        let result = try TodoActions.toggleCompletion(todoId: todo.id, using: repository)
+        WidgetReloader.reloadAllWidgets()
+
+        #if os(iOS)
+        if result.isNowCompleted {
+            await endMatchingLiveActivity(for: todo.id)
+        }
+        #endif
+
+        return .result(value: result.entity)
+    }
+
+    #if os(iOS)
+    @MainActor
+    private func endMatchingLiveActivity(for todoId: String) async {
+        for activity in Activity<TodoDeadlineActivityAttributes>.activities
+        where activity.attributes.todoId == todoId {
+            await activity.end(dismissalPolicy: .immediate)
+        }
+    }
+    #endif
+}
+
+#if os(iOS)
+extension ToggleTodoCompletionFromExtensionIntent: LiveActivityIntent {}
+#endif

--- a/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/ToggleTodoCompletionIntent.swift
+++ b/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/ToggleTodoCompletionIntent.swift
@@ -1,21 +1,16 @@
 //
 //  ToggleTodoCompletionIntent.swift
-//  IntentTodo
+//  TodoAppIntents
+//
+//  Primary variant: runs in the main app process via @Dependency.
+//  For widget / Live Activity contexts, use ToggleTodoCompletionFromExtensionIntent.
 //
 
-#if os(iOS)
-import ActivityKit
-#endif
 import AppIntents
 import Domain
 import Repository
 import SwiftData
 
-/// Toggles the completion status of a todo item.
-///
-/// Conforms to `LiveActivityIntent` on iOS so the same intent can be triggered
-/// from Dynamic Island / lock screen buttons. When a todo becomes completed,
-/// any active Live Activity for that todo is ended automatically.
 public struct ToggleTodoCompletionIntent: AppIntent {
     public static var title: LocalizedStringResource { "Toggle Todo Completion" }
 
@@ -48,37 +43,8 @@ public struct ToggleTodoCompletionIntent: AppIntent {
     @MainActor
     public func perform() async throws -> some IntentResult & ReturnsValue<TodoAppEntity> {
         let repository = SwiftDataTodoRepository(modelContext: modelContainer.mainContext)
-
-        guard let uuid = UUID(uuidString: todo.id),
-              let todoItem = try repository.fetch(by: uuid) else {
-            throw IntentError.notFound("Todo not found")
-        }
-
-        todoItem.isCompleted.toggle()
-        try repository.update(todoItem)
+        let result = try TodoActions.toggleCompletion(todoId: todo.id, using: repository)
         WidgetReloader.reloadAllWidgets()
-
-        // If the todo is now completed, end any matching Live Activity.
-        #if os(iOS)
-        if todoItem.isCompleted {
-            await endMatchingLiveActivity(for: todo.id)
-        }
-        #endif
-
-        return .result(value: TodoAppEntity(from: todoItem))
+        return .result(value: result.entity)
     }
-
-    #if os(iOS)
-    @MainActor
-    private func endMatchingLiveActivity(for todoId: String) async {
-        for activity in Activity<TodoDeadlineActivityAttributes>.activities
-        where activity.attributes.todoId == todoId {
-            await activity.end(dismissalPolicy: .immediate)
-        }
-    }
-    #endif
 }
-
-#if os(iOS)
-extension ToggleTodoCompletionIntent: LiveActivityIntent {}
-#endif

--- a/Packages/TodoAppIntents/Sources/TodoAppIntents/Shortcuts/TodoAppShortcuts.swift
+++ b/Packages/TodoAppIntents/Sources/TodoAppIntents/Shortcuts/TodoAppShortcuts.swift
@@ -2,21 +2,15 @@
 //  TodoAppShortcuts.swift
 //  TodoAppIntents
 //
-//  Provides App Shortcuts for the Todo app.
+//  Registers Primary intents as App Shortcuts so they appear in Siri, Shortcuts,
+//  and Spotlight. FromExtension variants are intentionally NOT registered.
 //
 
 import AppIntents
 
-/// Provides App Shortcuts for the Todo app.
-///
-/// App Shortcuts allow users to quickly access app features via Siri,
-/// the Shortcuts app, and Spotlight.
 public struct TodoAppShortcuts: AppShortcutsProvider {
-    // MARK: - App Shortcuts
-
-    /// The shortcuts available for this app.
     public static var appShortcuts: [AppShortcut] {
-        // Add a new todo
+        // Create
         AppShortcut(
             intent: AddTodoIntent(),
             phrases: [
@@ -24,11 +18,11 @@ public struct TodoAppShortcuts: AppShortcutsProvider {
                 "Create a new todo in \(.applicationName)",
                 "New todo in \(.applicationName)"
             ],
-            shortTitle: LocalizedStringResource("Add Todo", comment: "Add todo shortcut title"),
+            shortTitle: LocalizedStringResource("Add Todo"),
             systemImageName: "plus.circle"
         )
 
-        // Show all todos
+        // Query: all / incomplete / favorites
         AppShortcut(
             intent: ShowTodosIntent(),
             phrases: [
@@ -37,11 +31,10 @@ public struct TodoAppShortcuts: AppShortcutsProvider {
                 "What are my todos in \(.applicationName)",
                 "Open \(.applicationName)"
             ],
-            shortTitle: LocalizedStringResource("Show Todos", comment: "Show todos shortcut title"),
+            shortTitle: LocalizedStringResource("Show Todos"),
             systemImageName: "list.bullet"
         )
 
-        // Show incomplete todos
         AppShortcut(
             intent: ShowTodosIntent(filter: .incomplete),
             phrases: [
@@ -49,14 +42,10 @@ public struct TodoAppShortcuts: AppShortcutsProvider {
                 "What do I need to do in \(.applicationName)",
                 "Show unfinished tasks in \(.applicationName)"
             ],
-            shortTitle: LocalizedStringResource(
-                "Incomplete Todos",
-                comment: "Incomplete todos shortcut title"
-            ),
+            shortTitle: LocalizedStringResource("Incomplete Todos"),
             systemImageName: "circle"
         )
 
-        // Show favorite todos
         AppShortcut(
             intent: ShowTodosIntent(filter: .favorites),
             phrases: [
@@ -64,11 +53,79 @@ public struct TodoAppShortcuts: AppShortcutsProvider {
                 "Show starred todos in \(.applicationName)",
                 "Important todos in \(.applicationName)"
             ],
-            shortTitle: LocalizedStringResource(
-                "Favorite Todos",
-                comment: "Favorite todos shortcut title"
-            ),
+            shortTitle: LocalizedStringResource("Favorite Todos"),
             systemImageName: "star"
         )
+
+        // Toggle completion (Primary; user picks a todo)
+        AppShortcut(
+            intent: ToggleTodoCompletionIntent(),
+            phrases: [
+                "Toggle todo completion in \(.applicationName)",
+                "Mark todo in \(.applicationName)",
+                "Complete todo in \(.applicationName)"
+            ],
+            shortTitle: LocalizedStringResource("Toggle Completion"),
+            systemImageName: "checkmark.circle"
+        )
+
+        // Toggle favorite
+        AppShortcut(
+            intent: ToggleFavoriteIntent(),
+            phrases: [
+                "Toggle favorite in \(.applicationName)",
+                "Star todo in \(.applicationName)"
+            ],
+            shortTitle: LocalizedStringResource("Toggle Favorite"),
+            systemImageName: "star.circle"
+        )
+
+        // Delete
+        AppShortcut(
+            intent: DeleteTodoIntent(),
+            phrases: [
+                "Delete todo in \(.applicationName)",
+                "Remove todo in \(.applicationName)"
+            ],
+            shortTitle: LocalizedStringResource("Delete Todo"),
+            systemImageName: "trash"
+        )
+
+        // Snooze
+        AppShortcut(
+            intent: SnoozeTodoIntent(),
+            phrases: [
+                "Snooze todo in \(.applicationName)",
+                "Delay todo deadline in \(.applicationName)"
+            ],
+            shortTitle: LocalizedStringResource("Snooze Todo"),
+            systemImageName: "clock.arrow.circlepath"
+        )
+
+        // Toggle urgent todo (no parameter — auto-selects)
+        AppShortcut(
+            intent: ToggleUrgentTodoIntent(),
+            phrases: [
+                "Toggle urgent todo in \(.applicationName)",
+                "Complete my most urgent todo in \(.applicationName)"
+            ],
+            shortTitle: LocalizedStringResource("Toggle Urgent Todo"),
+            systemImageName: "clock.badge.exclamationmark"
+        )
+
+        // Todo count summary
+        AppShortcut(
+            intent: ShowTodoCountIntent(),
+            phrases: [
+                "Show todo count in \(.applicationName)",
+                "How many todos do I have in \(.applicationName)"
+            ],
+            shortTitle: LocalizedStringResource("Show Todo Count"),
+            systemImageName: "number.circle"
+        )
+
+        // Note: `LaunchAppIntent` is used by widgets / control widgets for navigation.
+        // Not registered as an App Shortcut because Apple limits AppShortcuts to 10
+        // and "Open X" phrases are already covered by `ShowTodosIntent`.
     }
 }


### PR DESCRIPTION
## Summary

同じアクションを実行プロセス別に Primary / FromExtension の 2 系統に分離。ビジネスロジックは `TodoActions` に集約して重複を排除。

- Primary: `@Dependency var modelContainer` → メインアプリ前提
- FromExtension: `SharedModelContainer.createContainer()` → プロセス独立

Live Activity の EXC_BREAKPOINT 問題は別タスクで切り分けるが、その準備として Live Activity から呼ばれる Intent を FromExtension 版に差し替え。

Apple 上限 (AppShortcuts 10 本) に合わせて `LaunchAppIntent` のみ AppShortcuts から除外（widget 用で Siri 発話向きではないため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)