### PR TITLE
docs: Primary/FromExtension 分離パターンと Widget reload ルールを明文化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,50 @@ public struct TodoIntentsPackage: AppIntentsPackage { }
 
 メインアプリ側には何も宣言しなくてよい。パッケージの Intent は自動的にアプリの Intent として登録される。
 
+### Primary / FromExtension 分離パターン
+
+同じアクションでも「**ユーザーがパラメータを直接選ぶか**」で Intent を 2 系統に分ける。
+
+| 区分 | 呼出元 | パラメータ型 | `isDiscoverable` | AppShortcuts 登録 |
+|------|-------|------------|------------------|--------------------|
+| **Primary** | Siri / Shortcuts / UI | `TodoAppEntity`（`@Parameter`） | `true` (default) | ✅ |
+| **FromExtension** | Live Activity / Widget（todoId を既に持っている） | `String`（UUID 文字列） | `false` | ❌ |
+
+**なぜ分けるか**: App Intents は `@Parameter var todo: TodoAppEntity` を持つ Intent を実行する前に `TodoEntityQuery.entities(for:)` を呼んで entity を解決する。Live Activity Extension プロセスで解決されると SwiftData が内部 assertion で trap することがあるため、呼出元が todoId を既に持っているケースでは entity 解決を経由しない `String` パラメータ版を用意する。
+
+```swift
+// Primary
+public struct ToggleTodoCompletionIntent: AppIntent {
+    @Parameter(title: "Todo") public var todo: TodoAppEntity
+    @Dependency var modelContainer: ModelContainer
+    // ...
+}
+
+// FromExtension (LA ボタン用)
+public struct ToggleTodoCompletionFromExtensionIntent: AppIntent {
+    public static let isDiscoverable = false
+    @Parameter(title: "Todo ID") public var todoId: String
+    @Dependency var modelContainer: ModelContainer
+    // ...
+}
+#if os(iOS)
+extension ToggleTodoCompletionFromExtensionIntent: LiveActivityIntent {}
+#endif
+```
+
+ビジネスロジックは両者で共通のため `Actions/TodoActions.swift` に切り出し、両方から呼ぶ。
+
+### データ更新 Intent は必ず `WidgetReloader.reloadAllWidgets()` を呼ぶ
+
+データ変更があった Intent は、UI / Widget 反映のため末尾で `WidgetReloader.reloadAllWidgets()` を呼ぶ。
+
+```swift
+try repository.update(item)
+WidgetReloader.reloadAllWidgets()
+```
+
+対象: `AddTodoIntent`, `DeleteTodoIntent`, `ToggleTodoCompletionIntent`, `ToggleFavoriteIntent`, `SnoozeTodoIntent`, `ToggleUrgentTodoIntent` と FromExtension 系。
+
 ### @Dependency + AppDependencyManager パターン
 
 Intent がアプリの共有状態（`ModelContainer`、`NavigationModel` 等）にアクセスする場合、`AppDependencyManager` に同期登録し Intent 側で `@Dependency` で取得する。

--- a/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/ToggleUrgentTodoIntent.swift
+++ b/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/ToggleUrgentTodoIntent.swift
@@ -39,6 +39,7 @@ public struct ToggleUrgentTodoIntent: AppIntent {
         let isNowCompleted = todo.isCompleted
         try context.save()
 
+        WidgetReloader.reloadAllWidgets()
         ControlNotificationHelper.sendToggledNotification(
             todoTitle: todoTitle,
             isCompleted: isNowCompleted

--- a/docs/insights/03-app-intents-core.md
+++ b/docs/insights/03-app-intents-core.md
@@ -276,6 +276,73 @@ func perform() async throws -> some IntentResult {
 
 ---
 
+## Primary / FromExtension 分離パターン
+
+同じ行動でも「**ユーザーがパラメータを直接選ぶか**」で実装を分ける。
+
+### 背景
+
+App Intents が `TodoAppEntity` のような `AppEntity` をパラメータに取る Intent を実行すると、`perform()` 前に `TodoEntityQuery.entities(for:)` を呼んで ID から entity を再解決する。この解決処理が Live Activity Extension プロセスで SwiftData の内部 assertion を踏んで `EXC_BREAKPOINT` で crash することが実機で確認された（2026-04-14）。
+
+スタック:
+```
+SwiftData`___lldb_unnamed_symbol_9d14c + 356
+SwiftData`dispatch thunk of ModelContext.fetch(_:) + 20
+SwiftDataTodoRepository.fetch(id:)   ← TodoEntityQuery から呼ばれる
+TodoEntityQuery.entities(for:)       ← parameter resolution 段階
+```
+
+### 解決策: 2 系統に分ける
+
+| 区分 | パラメータ | `isDiscoverable` | AppShortcuts | 用途 |
+|------|----------|------------------|--------------|------|
+| **Primary** | `todo: TodoAppEntity` | `true` | ✅ 登録 | Siri / Shortcuts / UI — ユーザーが todo を picker で選ぶ |
+| **FromExtension** | `todoId: String` | `false` | ❌ | Live Activity / Widget — 呼出元が todoId を既知 |
+
+String パラメータなら entity 解決を経由せず `perform()` に直行できる。
+
+```swift
+// Primary
+public struct ToggleTodoCompletionIntent: AppIntent {
+    @Parameter(title: "Todo") public var todo: TodoAppEntity
+    @Dependency var modelContainer: ModelContainer
+    // ...
+}
+
+// FromExtension
+public struct ToggleTodoCompletionFromExtensionIntent: AppIntent {
+    public static let isDiscoverable = false
+    @Parameter(title: "Todo ID") public var todoId: String
+    @Dependency var modelContainer: ModelContainer
+    // ...
+}
+#if os(iOS)
+extension ToggleTodoCompletionFromExtensionIntent: LiveActivityIntent {}
+#endif
+```
+
+### 共通ロジックの切り出し
+
+重複を避けるため `Actions/TodoActions.swift` に `@MainActor` 関数群として切り出し、両系統から呼ぶ。
+
+```swift
+public enum TodoActions {
+    @MainActor
+    public static func toggleCompletion(
+        todoId: String,
+        using repository: any TodoRepositoryProtocol
+    ) throws -> TodoToggleResult { /* ... */ }
+}
+```
+
+### DI は両者共通で @Dependency
+
+`@Dependency var modelContainer: ModelContainer` は Primary / FromExtension 両方で使える。`AppDependencyManager` への登録を `App.init()` と `WidgetBundle.init()` で済ませてあれば、どのプロセスで実行されても解決される（詳細は `04-ui-integration.md` の実行プロセス表）。
+
+> **補足**: かつて FromExtension では `SharedModelContainer.createContainer()` を直接呼ぶ方針にしたが、crash の真因は DI ではなく entity 解決だったと判明したので統一。
+
+---
+
 ## Intent 統合のベストプラクティス
 
 ### 重複Intentの検出と統合

--- a/docs/insights/07-platform-specific.md
+++ b/docs/insights/07-platform-specific.md
@@ -66,6 +66,32 @@ Live Activity から Activity の開始/更新/終了を伴うアクションを
 | `LiveActivityIntent` | Dynamic Island/ロック画面（Live Activity ボタン） | アプリプロセス（公式保証） |
 | `ControlConfigurationIntent` | コントロールセンター設定値 | Extension 配置必須 |
 
+### Live Activity Intent のパラメータは String ID にする（Entity を取らない）
+
+Live Activity ボタンから呼ぶ Intent は `@Parameter var todo: TodoAppEntity` ではなく `@Parameter var todoId: String` を使う。
+
+**理由**: App Intents は `AppEntity` パラメータを持つ Intent を実行する前に `TodoEntityQuery.entities(for:)` を呼んで entity を解決する。Live Activity Extension プロセスで解決処理が走ると SwiftData の内部 assertion に引っかかり `EXC_BREAKPOINT` で crash する（2026-04-14 の実機検証で判明）。呼出元の LA ボタンはすでに `context.attributes.todoId` を持っているため、Entity 解決は不要。
+
+```swift
+public struct ToggleTodoCompletionFromExtensionIntent: AppIntent {
+    public static let isDiscoverable = false  // Shortcuts 非表示
+    @Parameter(title: "Todo ID") public var todoId: String
+    // ...
+}
+#if os(iOS)
+extension ToggleTodoCompletionFromExtensionIntent: LiveActivityIntent {}
+#endif
+
+// Live Activity View 側
+Button(intent: ToggleTodoCompletionFromExtensionIntent(
+    todoId: context.attributes.todoId
+)) {
+    Label("Complete", systemImage: "checkmark.circle.fill")
+}
+```
+
+Primary 系（Shortcuts / UI で呼ぶもの）は従来通り `@Parameter var todo: TodoAppEntity` のままで良い（そちらは entity 解決が正常に動く文脈で使われる）。詳細は `03-app-intents-core.md` の「Primary / FromExtension 分離パターン」参照。
+
 ---
 
 ## Live Activity の自動管理


### PR DESCRIPTION
## Summary

Live Activity の EXC_BREAKPOINT 問題の解決過程で確立した設計ルールをドキュメント化。

- Primary / FromExtension の分離理由と判断基準
- 共通ロジック切り出し (TodoActions)
- WidgetReloader の呼び出しルール統一
- ToggleUrgentTodoIntent にも WidgetReloader 追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)