### PR TITLE
feat: Intent 結果を Dialog / 通知で使い分け

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,23 @@ extension ToggleTodoCompletionFromExtensionIntent: LiveActivityIntent {}
 
 ビジネスロジックは両者で共通のため `Actions/TodoActions.swift` に切り出し、両方から呼ぶ。
 
+### Dialog vs 通知の使い分け
+
+Intent の実行結果をユーザーに伝える方法は呼出元で見え方が異なる:
+
+| 呼出元 | `.result(dialog:)` | ローカル通知 |
+|-------|------------------|------------|
+| Siri | 読み上げ ✅ | 表示 ✅ |
+| Shortcuts | 結果欄に表示 ✅ | 表示 ✅ |
+| UI (`Button(intent:)`) | 表示なし | 表示 ✅ |
+| Widget `Button(intent:)` | 表示なし | 表示 ✅ |
+| **Control Widget (`ControlWidgetButton`)** | **表示なし** (2026-04-14 実機検証) | 表示 ✅ |
+
+使い分けルール:
+- **Control Center から呼ばれる Intent** (`ToggleUrgentTodoIntent`, `ShowTodoCountIntent`): **ローカル通知**でフィードバック (Dialog が表示されないため)
+- **Siri / Shortcuts 前提の Intent** (`ShowTodosIntent` 等): **Dialog** で結果を音声読み上げ / テキスト表示
+- **UI Button 経由が中心の Intent** (Add/Toggle/Delete 等): Dialog も通知も不要 (UI が即座に反映するため)
+
 ### データ更新 Intent は必ず `WidgetReloader.reloadAllWidgets()` を呼ぶ
 
 データ変更があった Intent は、UI / Widget 反映のため末尾で `WidgetReloader.reloadAllWidgets()` を呼ぶ。

--- a/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/ShowTodoCountIntent.swift
+++ b/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/ShowTodoCountIntent.swift
@@ -22,14 +22,16 @@ public struct ShowTodoCountIntent: AppIntent {
     public init() {}
 
     @MainActor
-    public func perform() async throws -> some IntentResult {
+    public func perform() async throws -> some IntentResult & ReturnsValue<Int> {
         let context = modelContainer.mainContext
         let descriptor = FetchDescriptor<TodoItem>(
             predicate: #Predicate { !$0.isCompleted }
         )
         let count = (try? context.fetchCount(descriptor)) ?? 0
 
+        // Control Center では Dialog が表示されない (2026-04-14 検証済み) ため通知で返す。
+        // ReturnsValue<Int> は Siri / Shortcuts から呼んだときの後続アクション用途。
         ControlNotificationHelper.sendTodoCountNotification(count: count)
-        return .result()
+        return .result(value: count)
     }
 }

--- a/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/ShowTodosIntent.swift
+++ b/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/ShowTodosIntent.swift
@@ -32,7 +32,7 @@ public struct ShowTodosIntent: AppIntent {
     }
 
     @MainActor
-    public func perform() async throws -> some IntentResult & ReturnsValue<[TodoAppEntity]> & OpensIntent {
+    public func perform() async throws -> some IntentResult & ReturnsValue<[TodoAppEntity]> & ProvidesDialog & OpensIntent {
         let repository = SwiftDataTodoRepository(modelContext: modelContainer.mainContext)
         let todos: [TodoItem]
         let screenTarget: AppScreenTarget
@@ -52,8 +52,31 @@ public struct ShowTodosIntent: AppIntent {
         let entities = todos.map { TodoAppEntity(from: $0) }
         return .result(
             value: entities,
-            opensIntent: LaunchAppIntent(target: screenTarget)
+            opensIntent: LaunchAppIntent(target: screenTarget),
+            dialog: dialog(for: entities)
         )
+    }
+
+    // MARK: - Dialog
+
+    /// Siri/Shortcuts の結果表示 / 読み上げ用メッセージ。
+    /// Control Center からの呼出では表示されないが、データ更新が無いためフィードバック不要。
+    private func dialog(for entities: [TodoAppEntity]) -> IntentDialog {
+        let count = entities.count
+        let categoryLabel: String = {
+            switch filter {
+            case .all: return "todo"
+            case .incomplete: return "incomplete todo"
+            case .completed: return "completed todo"
+            case .favorites: return "favorite todo"
+            }
+        }()
+
+        if count == 0 {
+            return IntentDialog("No \(categoryLabel)s.")
+        }
+        let plural = count == 1 ? categoryLabel : "\(categoryLabel)s"
+        return IntentDialog("You have \(count) \(plural).")
     }
 }
 

--- a/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/ToggleUrgentTodoIntent.swift
+++ b/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/ToggleUrgentTodoIntent.swift
@@ -40,6 +40,8 @@ public struct ToggleUrgentTodoIntent: AppIntent {
         try context.save()
 
         WidgetReloader.reloadAllWidgets()
+        // Control Center では Dialog が表示されない (2026-04-14 検証済み) ため、
+        // 通知でフィードバックを返す。
         ControlNotificationHelper.sendToggledNotification(
             todoTitle: todoTitle,
             isCompleted: isNowCompleted


### PR DESCRIPTION
Control Widget では `.result(dialog:)` が表示されない (実機検証済み) ため、呼出元に応じて使い分け。

- `ShowTodosIntent`: Siri 読み上げ用 Dialog 追加
- `ShowTodoCountIntent`: ReturnsValue<Int> + 通知 (Dialog は表示されないため)
- `ToggleUrgentTodoIntent`: 通知維持
- CLAUDE.md に使い分けルールを明文化

🤖 Generated with [Claude Code](https://claude.com/claude-code)