### PR TITLE
fix: Skill レビュー指摘 PR1 — シート誤クローズと Detail 不整合の解消 (Issue #36 B1-B3)

### DIFF
--- a/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/AddTodoIntent.swift
+++ b/Packages/TodoAppIntents/Sources/TodoAppIntents/Intents/AddTodoIntent.swift
@@ -56,6 +56,9 @@ public struct AddTodoIntent: AppIntent {
     @Dependency
     var todoService: TodoService
 
+    @Dependency
+    var navigationModel: NavigationModel
+
     // MARK: - Initialization
 
     public init() {}
@@ -83,6 +86,11 @@ public struct AddTodoIntent: AppIntent {
             dueDate: dueDate,
             isFavorite: isFavorite
         )
+        // UI から呼ばれた場合は Add シートを閉じる。Siri / Shortcuts / Widget から
+        // 呼ばれた場合は元から閉じているので no-op。@Query の件数差分でシートを
+        // 閉じていた旧実装は他デバイス / Widget からの追加で誤クローズしたため、
+        // Intent 完了 = シート閉じるという 1 対 1 対応に集約した。
+        navigationModel.dismissAddTodo()
         return .result(value: entity)
     }
 }

--- a/Packages/UI/Sources/UI/Views/TodoDetail/TodoDetailView.swift
+++ b/Packages/UI/Sources/UI/Views/TodoDetail/TodoDetailView.swift
@@ -12,19 +12,52 @@ import TodoAppIntents
 ///
 /// Actions use `Button(intent:)` for consistency with App Intents architecture.
 public struct TodoDetailView: View {
-    @Query private var todoItems: [TodoItem]
-    @Environment(\.dismiss) private var dismiss
-
-    private var todo: TodoItem? { todoItems.first }
+    let todo: TodoAppEntity
 
     public init(todo: TodoAppEntity) {
-        // TodoAppEntity.id (String) → UUID 変換に失敗したら何もマッチしないように
-        // ランダム UUID でフィルタする (ContentUnavailableView に落ちる)。
-        let targetId = UUID(uuidString: todo.id) ?? UUID()
-        _todoItems = Query(filter: #Predicate<TodoItem> { $0.id == targetId })
+        self.todo = todo
     }
 
     public var body: some View {
+        // `TodoAppEntity.id` (String) → `UUID` の parse に失敗したら、@Query を
+        // 投げずに不在表示へ落とす。旧実装はランダム UUID で必ずヒットしないクエリ
+        // を発行していたため SwiftData 側に無駄な往復が発生していた。
+        if let targetId = UUID(uuidString: todo.id) {
+            TodoDetailQueryView(targetId: targetId, fallbackTitle: todo.title)
+        } else {
+            ContentUnavailableView(
+                "Todo Not Found",
+                systemImage: "questionmark.circle",
+                description: Text("This todo may have been deleted.")
+            )
+            .navigationTitle(todo.title)
+            #if os(iOS) || os(visionOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+        }
+    }
+}
+
+// MARK: - Query Wrapper
+
+/// `@Query` を発行するのは parse 成功後のみ。`@Environment(\.dismiss)` は
+/// NavigationSplitView の detail ペインでは効かないため、todo 消滅時は
+/// `NavigationModel.selectedTodo = nil` で selection を解除する (compact width で
+/// 折り畳まれた NavigationStack 上でも selection クリアで自動 pop する)。
+private struct TodoDetailQueryView: View {
+    @Query private var todoItems: [TodoItem]
+    @Environment(NavigationModel.self) private var navigationModel
+
+    let fallbackTitle: String
+
+    private var todo: TodoItem? { todoItems.first }
+
+    init(targetId: UUID, fallbackTitle: String) {
+        self.fallbackTitle = fallbackTitle
+        _todoItems = Query(filter: #Predicate<TodoItem> { $0.id == targetId })
+    }
+
+    var body: some View {
         Group {
             if let todo {
                 TodoDetailContent(todo: todo)
@@ -37,13 +70,15 @@ public struct TodoDetailView: View {
             }
         }
         // Detail のタイトルは選択中の todo タイトルを反映 (macOS Mail / Notes と同じ慣習)。
-        // Todo が消えたケースでは "Details" にフォールバック。
-        .navigationTitle(todo?.title ?? "Details")
+        // Todo が消えたケースでは選択時のタイトルを保持して読みやすさを保つ。
+        .navigationTitle(todo?.title ?? fallbackTitle)
         #if os(iOS) || os(visionOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif
         .onChange(of: todo) { _, newValue in
-            if newValue == nil { dismiss() }
+            if newValue == nil {
+                navigationModel.selectedTodo = nil
+            }
         }
     }
 }

--- a/Packages/UI/Sources/UI/Views/TodoList/TodoListView.swift
+++ b/Packages/UI/Sources/UI/Views/TodoList/TodoListView.swift
@@ -74,7 +74,7 @@ public struct TodoListView: View {
             }
         }
         .sheet(isPresented: $navigationModel.showingAddTodo) {
-            AddTodoSheet(todoCount: todoItems.count)
+            AddTodoSheet()
         }
         #if os(iOS)
         .monitorLiveActivities(for: todoItems)
@@ -196,11 +196,10 @@ private struct TodoListToolbar: ToolbarContent {
 
 // MARK: - Add Todo Sheet
 
+/// Sheet container for `AddTodoView`. Dismissal is driven by `AddTodoIntent.perform()`
+/// which calls `navigationModel.dismissAddTodo()` on success — no need to observe
+/// `@Query` count drift here.
 private struct AddTodoSheet: View {
-    let todoCount: Int
-    @Environment(NavigationModel.self) private var navigationModel
-    @State private var baselineCount: Int?
-
     var body: some View {
         #if os(macOS)
         // macOS では NavigationStack + navigationTitle がタイトル上に大きな余白を
@@ -209,24 +208,11 @@ private struct AddTodoSheet: View {
         // ウィンドウバーに自動配置される。
         AddTodoView()
             .frame(minWidth: 520, minHeight: 420)
-            .task { baselineCount = todoCount }
-            .onChange(of: todoCount) { _, newValue in
-                if let baseline = baselineCount, newValue > baseline {
-                    navigationModel.dismissAddTodo()
-                }
-            }
         #else
         NavigationStack {
             AddTodoView()
         }
         .presentationDetents([.medium])
-        .task { baselineCount = todoCount }
-        .onChange(of: todoCount) { _, newValue in
-            // シート開いた時点より件数が増えていれば Intent が成功したと判定しシートを閉じる。
-            if let baseline = baselineCount, newValue > baseline {
-                navigationModel.dismissAddTodo()
-            }
-        }
         #endif
     }
 }

--- a/Packages/UI/Sources/UI/Views/VisionOS/VisionOSTodoView.swift
+++ b/Packages/UI/Sources/UI/Views/VisionOS/VisionOSTodoView.swift
@@ -42,7 +42,7 @@ public struct VisionOSTodoListView: View {
             VisionOSBottomOrnament(viewModel: $viewModel)
         }
         .sheet(isPresented: $navigationModel.showingAddTodo) {
-            VisionOSAddTodoSheet(todoCount: todoItems.count)
+            VisionOSAddTodoSheet()
         }
     }
 }
@@ -163,22 +163,15 @@ private struct VisionOSBottomOrnament: View {
 
 // MARK: - Add Sheet
 
+/// Sheet container for `AddTodoView` on visionOS. Dismissal is driven by
+/// `AddTodoIntent.perform()` via `navigationModel.dismissAddTodo()` — no need to
+/// observe `@Query` count drift here.
 private struct VisionOSAddTodoSheet: View {
-    let todoCount: Int
-    @Environment(NavigationModel.self) private var navigationModel
-    @State private var baselineCount: Int?
-
     var body: some View {
         NavigationStack {
             AddTodoView()
         }
         .frame(minWidth: 400, minHeight: 300)
-        .task { baselineCount = todoCount }
-        .onChange(of: todoCount) { _, newValue in
-            if let baseline = baselineCount, newValue > baseline {
-                navigationModel.dismissAddTodo()
-            }
-        }
     }
 }
 
@@ -248,12 +241,31 @@ struct VisionOSTodoRow: View {
 
 struct VisionOSTodoDetailView: View {
     let todo: TodoAppEntity
-    @Query private var todoItems: [TodoItem]
-    private var todoItem: TodoItem? { todoItems.first }
 
     init(todo: TodoAppEntity) {
         self.todo = todo
-        let targetId = UUID(uuidString: todo.id) ?? UUID()
+    }
+
+    var body: some View {
+        // UUID parse に失敗した場合は @Query を投げずに不在表示へ落とす。
+        if let targetId = UUID(uuidString: todo.id) {
+            VisionOSTodoDetailQueryView(targetId: targetId)
+        } else {
+            ContentUnavailableView(
+                "Todo Not Found",
+                systemImage: "questionmark.circle",
+                description: Text("This todo may have been deleted.")
+            )
+            .navigationTitle("Details")
+        }
+    }
+}
+
+private struct VisionOSTodoDetailQueryView: View {
+    @Query private var todoItems: [TodoItem]
+    private var todoItem: TodoItem? { todoItems.first }
+
+    init(targetId: UUID) {
         _todoItems = Query(filter: #Predicate<TodoItem> { $0.id == targetId })
     }
 


### PR DESCRIPTION
## Summary

Issue #36 のうち、バグ系 High (B1-B3) を修正。

- **B1**: AddTodo シートを `@Query` の todoCount 差分でクローズしていたため、他デバイス / Widget 経由の追加で誤クローズしていた問題を、Intent 完了駆動の単純な仕組みに置換
- **B2**: NavigationSplitView の detail ペインでは `@Environment(\.dismiss)` が効かないため、`navigationModel.selectedTodo = nil` で代替
- **B3**: `UUID(uuidString:) ?? UUID()` でランダム UUID を発行して `@Query` していた問題を、parse 成功時のみ `@Query` する 2 段構成に分離

## 変更詳細

### B1 — AddTodoIntent → NavigationModel.dismissAddTodo()
- \`AddTodoIntent\` に \`@Dependency var navigationModel: NavigationModel\` を追加し、\`perform()\` 末尾で \`dismissAddTodo()\` を呼ぶ
- \`AddTodoSheet\` / \`VisionOSAddTodoSheet\` の \`baselineCount\` / \`onChange(of: todoCount)\` ロジックを丸ごと削除
- Siri / Shortcuts / Widget から呼ばれた場合は元から \`showingAddTodo\` が false なので no-op

### B2 — Detail ペインでの selection 解除
- \`TodoDetailView\` で \`@Environment(\.dismiss)\` を \`@Environment(NavigationModel.self)\` に置換
- todo 消滅時は \`navigationModel.selectedTodo = nil\`。compact width で折り畳まれた NavigationStack 上でも selection クリアで自動 pop する

### B3 — UUID parse 失敗時の処理
- \`TodoDetailView\` / \`VisionOSTodoDetailView\` を 2 段構成 (parse 判定 → \`Query\` 発行) に分離
- parse 失敗時は \`ContentUnavailableView\` を直接表示し、SwiftData の無駄な往復を排除

## 検証

- [x] SPM テスト全 pass: \`Domain\` (19) + \`Repository\` (16) + \`TodoAppIntents\` (60) = **95 件**
- [x] 既存 UI Test \`testAddTodo\` がシート閉鎖の暗黙カバー (シートが閉じないと list が露出しない)
- [ ] 実機検証 (Xcode iOS Simulator + 実 iPhone / iPad / visionOS / macOS) — 手元検証時に確認

## 影響範囲

| ファイル | 変更 |
|---|---|
| \`Packages/TodoAppIntents/.../AddTodoIntent.swift\` | \`@Dependency var navigationModel\` 追加 + \`perform()\` 末尾で \`dismissAddTodo()\` |
| \`Packages/UI/.../TodoListView.swift\` | \`AddTodoSheet\` 簡素化 |
| \`Packages/UI/.../VisionOSTodoView.swift\` | \`VisionOSAddTodoSheet\` 簡素化 + \`VisionOSTodoDetailView\` 2 段化 |
| \`Packages/UI/.../TodoDetailView.swift\` | 2 段化 + \`selectedTodo = nil\` 化 |

## 残タスク (別 PR で消化)

- PR2: Liquid Glass High (LG1-LG2)
- PR3: Performance High (P1-P4)
- PR4: 構造リファクタ Medium (View 分割 / 重複解消 / Color(hex:) 昇格 ほか)

Closes part of #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)