### PR TITLE
perf: List / LiveActivity / Watch の invalidation を圧縮 (Issue #36 P1-P4)

### DIFF
--- a/Packages/LiveActivity/Sources/LiveActivity/LiveActivityMonitor.swift
+++ b/Packages/LiveActivity/Sources/LiveActivity/LiveActivityMonitor.swift
@@ -17,10 +17,22 @@ private let logger = Logger(subsystem: "dev.touyou.IntentTodo", category: "LiveA
 struct LiveActivityMonitorModifier: ViewModifier {
     let todos: [TodoItem]
 
+    /// reconcile が反応すべき変化を絞った signature。dueDate を持たない todo は
+    /// Live Activity の対象外なので無視し、対象 todo の `id` / `isCompleted` /
+    /// `dueDate` のみを観測する。これにより dueDate 無 todo の追加・編集では
+    /// `.task` が再起動されなくなる (旧実装は全 todo の id 配列を毎更新で
+    /// 再アロケートしており、件数増で観測コストが線形に増えていた)。
+    private var monitorSignature: [String] {
+        todos.compactMap { todo in
+            guard let dueDate = todo.dueDate else { return nil }
+            return "\(todo.id.uuidString)|\(todo.isCompleted)|\(dueDate.timeIntervalSinceReferenceDate)"
+        }
+    }
+
     func body(content: Content) -> some View {
         // .task(id:) は id 変化のたびに自動でキャンセル＆再起動するので、
         // onChange + unstructured Task の組み合わせより安全でシリアル実行が保証される。
-        content.task(id: todos.map(\.id)) {
+        content.task(id: monitorSignature) {
             await checkAndReconcileActivities()
         }
     }

--- a/Packages/UI/Sources/UI/ViewModels/TodoListViewModel.swift
+++ b/Packages/UI/Sources/UI/ViewModels/TodoListViewModel.swift
@@ -3,6 +3,7 @@
 //  IntentTodo
 //
 
+import Domain
 import Foundation
 import TodoAppIntents
 
@@ -16,6 +17,7 @@ import TodoAppIntents
 /// - Sort order management
 /// - Search text management
 /// - Filtering and sorting logic (UI-specific, not used by Siri/Shortcuts)
+/// - Caching `TodoAppEntity` snapshots from `@Query` updates
 @MainActor
 @Observable
 public final class TodoListViewModel {
@@ -30,9 +32,24 @@ public final class TodoListViewModel {
     /// Search text for filtering todos.
     public var searchText = ""
 
+    // MARK: - Cached Entities
+
+    /// `@Query` から渡される `TodoItem` を `TodoAppEntity` に変換したキャッシュ。
+    /// View は `.onChange(of: todoItems, initial: true) { update(from:) }` で
+    /// 更新する。これにより entity 化のコストを body 評価のたびではなく Query
+    /// 更新時のみに限定できる (1,000 件規模でスクロール時のカクつきを抑える)。
+    public private(set) var entities: [TodoAppEntity] = []
+
     // MARK: - Initialization
 
     public init() {}
+
+    // MARK: - Cache Update
+
+    /// Updates the cached entity snapshot from the latest `@Query` result.
+    public func update(from todos: [TodoItem]) {
+        entities = todos.map { TodoAppEntity(from: $0) }
+    }
 
     // MARK: - Filtering & Sorting
 

--- a/Packages/UI/Sources/UI/Views/TodoList/TodoListView.swift
+++ b/Packages/UI/Sources/UI/Views/TodoList/TodoListView.swift
@@ -26,7 +26,10 @@ public struct TodoListView: View {
     // MARK: - Computed Properties
 
     private var filteredTodos: [TodoAppEntity] {
-        viewModel.filteredTodos(from: todoItems.map { TodoAppEntity(from: $0) })
+        // ViewModel が `@Query` 更新時に entities をキャッシュしているので、
+        // body 評価のたびに発生していた `todoItems.map { TodoAppEntity(from: $0) }`
+        // は不要。filter/sort のみここで適用する (filter/sort は item 数に対して軽量)。
+        viewModel.filteredTodos(from: viewModel.entities)
     }
 
     // MARK: - Initialization
@@ -76,6 +79,11 @@ public struct TodoListView: View {
         .sheet(isPresented: $navigationModel.showingAddTodo) {
             AddTodoSheet()
         }
+        // `@Query` 更新時に ViewModel の entity キャッシュを更新する。
+        // initial: true で最初のレンダリングにも反映される。
+        .onChange(of: todoItems, initial: true) {
+            viewModel.update(from: todoItems)
+        }
         #if os(iOS)
         .monitorLiveActivities(for: todoItems)
         #endif
@@ -89,6 +97,10 @@ private struct TodoListSidebar: View {
     @Binding var selection: TodoAppEntity?
 
     var body: some View {
+        // SwiftData @Query の delta 検出により List の行挿入/削除は標準で animate
+        // されるため、明示的な `.animation(value: todos.map(\.id))` は外す。旧実装は
+        // body 評価のたびに `[String]` 配列を再アロケートしていたため、件数が増える
+        // ほどスクロールがカクついていた。
         List(selection: $selection) {
             ForEach(todos, id: \.id) { todo in
                 TodoRowView(todo: todo)
@@ -98,7 +110,6 @@ private struct TodoListSidebar: View {
                     }
             }
         }
-        .animation(.default, value: todos.map(\.id))
     }
 }
 

--- a/Packages/UI/Sources/UI/Views/VisionOS/VisionOSTodoView.swift
+++ b/Packages/UI/Sources/UI/Views/VisionOS/VisionOSTodoView.swift
@@ -21,7 +21,8 @@ public struct VisionOSTodoListView: View {
     @Environment(NavigationModel.self) private var navigationModel
 
     private var filteredTodos: [TodoAppEntity] {
-        viewModel.filteredTodos(from: todoItems.map { TodoAppEntity(from: $0) })
+        // ViewModel が entities をキャッシュしているので body 内 map は不要。
+        viewModel.filteredTodos(from: viewModel.entities)
     }
 
     public init() {}
@@ -43,6 +44,9 @@ public struct VisionOSTodoListView: View {
         }
         .sheet(isPresented: $navigationModel.showingAddTodo) {
             VisionOSAddTodoSheet()
+        }
+        .onChange(of: todoItems, initial: true) {
+            viewModel.update(from: todoItems)
         }
     }
 }

--- a/Packages/WatchUI/Sources/WatchUI/Views/WatchTodoListView.swift
+++ b/Packages/WatchUI/Sources/WatchUI/Views/WatchTodoListView.swift
@@ -57,8 +57,23 @@ public struct WatchTodoListView: View {
     }
 
     private var todoList: some View {
-        List {
-            let dueSoon = incompleteTodos.filter { isDueSoon($0) }
+        // 旧実装は `incompleteTodos.filter { isDueSoon($0) }` と
+        // `incompleteTodos.filter { !isDueSoon($0) }` で同じ配列を 2 周し、
+        // さらに `isDueSoon` の中で `Date()` を都度生成していた。watchOS は
+        // CPU が弱いので 1 周の partition + Date() 1 回に圧縮する。
+        let now = Date()
+        let oneHourFromNow = now.addingTimeInterval(3600)
+        var dueSoon: [TodoItem] = []
+        var others: [TodoItem] = []
+        for todo in incompleteTodos {
+            if let dueDate = todo.dueDate, dueDate > now, dueDate <= oneHourFromNow {
+                dueSoon.append(todo)
+            } else {
+                others.append(todo)
+            }
+        }
+
+        return List {
             if !dueSoon.isEmpty {
                 Section("Due Soon") {
                     ForEach(dueSoon) { todo in
@@ -66,8 +81,6 @@ public struct WatchTodoListView: View {
                     }
                 }
             }
-
-            let others = incompleteTodos.filter { !isDueSoon($0) }
             if !others.isEmpty {
                 Section("Upcoming") {
                     ForEach(others.prefix(10)) { todo in
@@ -76,10 +89,5 @@ public struct WatchTodoListView: View {
                 }
             }
         }
-    }
-
-    private func isDueSoon(_ todo: TodoItem) -> Bool {
-        guard let dueDate = todo.dueDate else { return false }
-        return dueDate.timeIntervalSinceNow <= 3600 && dueDate.timeIntervalSinceNow > 0
     }
 }


### PR DESCRIPTION
## Summary

skill (\`swiftui-performance-audit\`) レビューの Performance High 4 件 (P1-P4) を消化。1,000 件規模で顕在化する body 内 entity 化 / id 配列再アロケート / 二重 filter を圧縮。

## 変更内容

| # | 場所 | Before | After |
|---|---|---|---|
| **P1** | TodoListView / VisionOSTodoView の \`filteredTodos\` | body 評価ごとに \`todoItems.map { TodoAppEntity(from: \$0) }\` | ViewModel の entity キャッシュを \`.onChange(of: todoItems, initial: true)\` で更新、body は filter/sort のみ |
| **P2** | TodoListSidebar | \`.animation(.default, value: todos.map(\.id))\` で毎回 \`[String]\` 再アロケート | 削除 (SwiftData @Query の delta 検出で List は標準 animation) |
| **P3** | LiveActivityMonitor | \`.task(id: todos.map(\.id))\` で全件観測 | \`dueDate\` を持つ todo のみの \`id\|isCompleted\|dueDate\` signature を観測。dueDate 無 todo の編集では reconcile 不発 |
| **P4** | WatchTodoListView | \`incompleteTodos.filter { isDueSoon(\$0) }\` を 2 回 + \`isDueSoon\` 内で \`Date()\` 都度生成 | 1 周 partition + \`Date()\` 1 回 |

## 設計判断

### TodoListViewModel API の互換性維持

- 新 API: \`update(from: [TodoItem])\` + \`public private(set) var entities\`
- 既存 \`filteredTodos(from:)\` / \`incompleteCount(from:)\` / \`favoriteCount(from:)\` は維持
  - テスト互換確保 (TodoListViewModelTests は \`TodoAppEntity\` 直渡しスタイル、\`@Model\` インスタンス化を SPM では避けたい)
  - View からの呼出経路は \`viewModel.filteredTodos(from: viewModel.entities)\` に変更

### LiveActivityMonitor の signature

\`.task(id:)\` が観測する値は \`Equatable\` でさえあれば良いので \`[String]\` を採用。\`Hasher\` ベースの圧縮も検討したが、結局 todos 全走査するため改善幅は薄い。dueDate を持つ todo に絞ることで、dueDate 無の大多数 todo の変更で reconcile が走らない設計に変えるほうが効果が大きい。

### \`.animation\` 削除の判断

SwiftData \`@Query\` の挿入/削除 delta は List 側で標準 animation される。明示的 \`.animation(value:)\` は filter 切替で「件数同じ・順序のみ変化」のケースを拾うために残す価値もあるが、現状その UX 上の必要性は薄いと判断して削除。必要になれば軽い signature で復活可能。

## 検証

- [x] SPM テスト全 pass: Domain 19 + Repository 16 + TodoAppIntents 60 = **95 件**
- [x] 既存 \`TodoListViewModelTests\` の \`filteredTodos(from:)\` 系は API 維持により無修正で動作 (UI パッケージは macOS swift test 不可、Xcode iOS Simulator 経由で要再確認)
- [ ] 実機検証 (1,000 件 Todo を seed してスクロール / Live Activity の reconcile 頻度) — 手元検証時に確認

## 残タスク (PR4)

- 構造リファクタ Medium (View 分割 / 重複解消 / Color(hex:) 昇格 / Widget incompleteCount precompute / TodoDetailSubtasks の body 内 sort / TodoListView selection を ID ベースに / Group{if/else} の identity 安定化)
- High Pattern PT1 (TodoListView.swift:39 の \`@Bindable\` 末端化) も Medium と同 PR で消化候補

Closes part of #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)