### PR TITLE
docs(skill): PR1-PR4 で得た教訓を intent-centric-architecture に反映

### DIFF
--- a/skills/intent-centric-architecture/SKILL.md
+++ b/skills/intent-centric-architecture/SKILL.md
@@ -25,7 +25,8 @@ Read these references as needed:
 - `references/04-process-and-dependencies.md` — `@Dependency` + `AppDependencyManager` across app process, Widget Extension process, and Live Activity Extension process; SPM packaging and `AppIntentsPackage` rules.
 - `references/05-ui-integration.md` — `onAppIntentExecution`, `AppIntentSceneDelegate`, and the cold-start fallback for early iOS 26.
 - `references/06-feedback-channels.md` — when Dialog is read aloud, when it is silent, and when to fall back to local notifications (Control Widget reality check).
-- `references/07-data-and-side-effects.md` — `WidgetReloader.reloadAllWidgets()`, idempotent intents, `TodoService`-style aggregation.
+- `references/07-data-and-side-effects.md` — `WidgetReloader.reloadAllWidgets()`, idempotent intents, `TodoService`-style aggregation, the SwiftData `@Query` + `.onChange(of:)` foot-gun.
+- `references/08-platform-quirks.md` — visionOS Liquid Glass API availability (`Glass*ButtonStyle` not on visionOS), watchOS CPU constraints, macOS `NavigationSplitView` detail-pane `dismiss()` no-op, multi-platform component consolidation, Liquid Glass philosophy ("where not to use it").
 - `references/code-templates.md` — copy-pasteable templates for Service-backed Intent, Primary+FromExtension pair, Entity+Query, `WidgetConfigurationIntent`, and `AppShortcutsProvider`.
 
 ## Core principles
@@ -87,6 +88,9 @@ Read these references as needed:
 - Adopting `ForegroundContinuableIntent` for new code. Apple deprecated it in favor of `supportedModes: [.background, .foreground(.dynamic)]`.
 - Declaring `AppIntentsPackage` in both the app target and a SPM package. Apps support exactly one.
 - Showing a `.result(dialog:)` from a Control Widget intent and assuming the user will see it.
+- Caching SwiftData `@Query` results in a `@Observable` view model via `.onChange(of: todoItems)` to avoid per-`body` mapping. `[PersistentModel]` is identity-equatable, so in-place attribute updates (toggle, edit) do not fire `.onChange` — your cache silently goes stale. Map directly in `body`, or use a SwiftData `struct` projection. (See `references/07-data-and-side-effects.md`.)
+- Adding `glassEffect` / `glassBackgroundEffect` to content surfaces (badges, chips, cards, list rows) "to be consistent with Liquid Glass". Apple's HIG positions Liquid Glass as a navigation-layer signal; the standard SwiftUI navigation chrome on iOS 26+ is already glass-rendered automatically. Decorating individual content elements creates noise. (See `references/08-platform-quirks.md`.)
+- Using `.buttonStyle(.glass)` / `.glassProminent` in code that compiles for visionOS — those styles are not available on visionOS. (See `references/08-platform-quirks.md`.)
 
 ## Notes
 
@@ -100,3 +104,4 @@ Read these references as needed:
 - App Intents API and platform behavior shifts every iOS cycle. When uncertain, web-search current Apple Developer documentation before committing to a pattern.
 - A healthy first pass usually contains: one open-app intent, two background action intents, one or two `AppEntity` types with a single `EntityQuery`, one `AppShortcutsProvider`, and one `Service` that owns the persistence calls — that is enough to ship to Shortcuts, Siri, Spotlight, and a basic widget.
 - Background reading on the design philosophy: <https://goodpatch-tech.hatenablog.com/entry/liquid_glass_and_app_intents>.
+- When using this skill alongside performance / Liquid Glass / SwiftUI-pattern reviewers (e.g. `swiftui-performance-audit`, `swiftui-liquid-glass`), treat their output as a *candidate list*, not a verdict. Reviewer skills tend to read guidelines as coverage targets ("this place could use feature X, therefore it should") and miss the more important Apple guidance of "where *not* to use it" or "what platform doesn't support it". Filter every suggestion against the data-flow and platform-availability constraints in this skill before adopting it.

--- a/skills/intent-centric-architecture/references/07-data-and-side-effects.md
+++ b/skills/intent-centric-architecture/references/07-data-and-side-effects.md
@@ -109,3 +109,42 @@ func perform() async throws -> some IntentResult & ProvidesDialog {
 | Navigation writes via `@Dependency var navigation` | ✅ | ❌ |
 
 Following this division keeps the Intent file small and the Service unit-testable in isolation, without `AppDependencyManager`.
+
+## SwiftData `@Query` and `.onChange(of:)` — a frequent foot-gun
+
+It is tempting to "optimize" away the per-`body` cost of converting `[TodoItem]` (SwiftData `@Model`) into a presentation type by caching the conversion in a `@Observable` view model and updating it via `.onChange(of: todoItems)`:
+
+```swift
+// ❌ This looks reasonable but is broken.
+@MainActor @Observable
+final class TodoListViewModel {
+    public private(set) var entities: [TodoAppEntity] = []
+    public func update(from todos: [TodoItem]) {
+        entities = todos.map { TodoAppEntity(from: $0) }
+    }
+}
+
+// In the view:
+.onChange(of: todoItems, initial: true) {
+    viewModel.update(from: todoItems)
+}
+```
+
+**Why it breaks**: SwiftData's `@Query` returns `[PersistentModel]`, where each element is a *class*. The array's `Equatable` is identity-based — comparing two snapshots checks whether the same objects are at the same indices, not whether their attributes have changed. So when the user toggles `isCompleted` or edits a `title` in place, `todoItems` is "the same" array, `.onChange(of: todoItems)` does **not** fire, and the cached `entities` go stale. Insertion/deletion (which changes the element identities) does fire `.onChange`, which is why this bug is invisible until you start mutating in place.
+
+**The fix**: do the conversion in `body`. SwiftUI's dependency tracking re-evaluates the view when SwiftData's tracked attributes change, so the in-place mutation propagates correctly. The per-`body` `map` is cheap up to a few hundred items.
+
+```swift
+// ✅ Correct.
+private var filteredTodos: [TodoAppEntity] {
+    viewModel.filteredTodos(from: todoItems.map { TodoAppEntity(from: $0) })
+}
+```
+
+**If you genuinely have thousands of items**, fix it by:
+
+- Using a SwiftData fetch that returns a lightweight `struct` projection (only the fields you need), so the `map` itself is unnecessary.
+- Filtering / sorting at the `@Query(filter:sort:)` macro level so the array reaching the view is already small.
+- Pushing pagination — show 100 at a time, load more on scroll.
+
+Do not reach for `.onChange(of: todoItems)` caching. The bug is silent and surfaces in production as "toggles don't update".

--- a/skills/intent-centric-architecture/references/08-platform-quirks.md
+++ b/skills/intent-centric-architecture/references/08-platform-quirks.md
@@ -1,0 +1,86 @@
+# 08 — Platform quirks (visionOS, Liquid Glass, watchOS)
+
+When the same Intent + Entity surface lights up on five platforms, the surface area for OS-specific quirks balloons. This reference collects the recurring ones — knowing them ahead of time saves a build cycle.
+
+## visionOS
+
+### `GlassButtonStyle` / `GlassProminentButtonStyle` — not available on visionOS
+
+`buttonStyle(.glass)` and `buttonStyle(.glassProminent)` are part of the iOS 26+ Liquid Glass API but visionOS does **not** ship these styles. Using them in code that compiles for visionOS will fail. visionOS-aware UI typically falls back to:
+
+- `.buttonStyle(.bordered)` / `.buttonStyle(.borderedProminent)` for the button shell, plus
+- `.contentShape(.hoverEffect, .capsule)` + `.hoverEffect(.highlight)` for spatial interactivity
+
+Apple's `Glass*ButtonStyle` documentation does not list visionOS in the Availability section (verified 2026-04). Re-check before assuming any new release adds support.
+
+### `glassBackgroundEffect()` is the visionOS-native API
+
+visionOS has its own `glassBackgroundEffect()` modifier (visionOS 1.0+) that pre-dates iOS 26's `glassEffect(_:in:)`. They are distinct APIs:
+
+- `glassBackgroundEffect()` — visionOS-only, applies the system spatial glass material.
+- `glassEffect(_:in:)` — iOS / iPadOS / macOS / watchOS / tvOS 26+, also visionOS 26+, the new Liquid Glass primitive.
+- `GlassEffectContainer` — iOS / iPadOS / macOS / watchOS / tvOS 26+, also visionOS 26+. Not yet documented as composing well with `glassBackgroundEffect()` — keep them in separate subtrees if you need both.
+
+### Spatial hover effects, not interactive glass
+
+For interactive surfaces in visionOS, prefer the spatial idiom (`hoverEffect(.highlight)` / `.lift`) over `glassEffect(.regular.interactive())`. The hover effect is the platform-native interactivity signal in spatial computing.
+
+## Liquid Glass philosophy — where to apply, where to refuse
+
+Apple's Liquid Glass HIG (WWDC25) is clearer on **where not to use it** than on where to use it. Standard SwiftUI navigation chrome on iOS 26+ is already glass-rendered automatically — you do not opt into it.
+
+| Layer | Liquid Glass | Examples |
+|---|---|---|
+| Navigation / system chrome | ✅ Automatic | toolbar, navigation bar, sidebar, tab bar |
+| Floating / ornament | ✅ Explicit | visionOS ornament, floating action button, hovering controls |
+| Content surface | ❌ Don't | badges, chips, cards, list rows, info sections |
+
+Skill-based reviewers (including the `swiftui-liquid-glass` skill) tend to suggest "you should add `.glassEffect` here too" wherever a `.background(color.opacity(...))` chip exists. **Resist.** Adding glass to content chips creates visual noise and dilutes the navigational signal that real Liquid Glass surfaces carry. If the surrounding navigation chrome is already glass and the standard SwiftUI controls are flowing through it, the user is already getting the Liquid Glass experience without you decorating individual content elements.
+
+Rule of thumb: if the element is *something the user reads*, do not glass it. If it is *something the user navigates with* or *something floating above content*, glass is fair game.
+
+### Reducing existing glass usage is also a refactor
+
+When inheriting a codebase that uses `glassBackgroundEffect()` on every section of a Detail view, the right refactor is usually to **remove the effect from content sections and keep it on the main surface (Header) and floating chrome (Ornament)**, not to migrate them all into a single `GlassEffectContainer`. The skill review may suggest "consolidate", but the real fix is "trim".
+
+## watchOS
+
+### CPU is the binding constraint
+
+watchOS hardware has materially weaker CPU than iPhone. Patterns that are merely "nice to clean up" on iOS are "shipping requirements" on watchOS:
+
+- Two `filter` calls on the same array → switch to a single-pass partition (loop with two `append` arrays).
+- Repeated `Date()` instantiation in a hot computation → hoist to a single `let now = Date()` at the start of the closure.
+- `body`-level `sorted` → move into `init` so the sort runs once per view instance, not per render.
+
+Mentally tag these patterns "must-fix on watchOS" rather than "would-be-nice", and audit them when designing watchOS variants from existing iOS code.
+
+### Liquid Glass is unavailable in the typical sense on watchOS
+
+Even though watchOS 26+ technically has the `glassEffect` API, the watchOS UX idiom does not call for it. The standard watchOS view chrome already provides the platform-native material. Apply `.glassEffect` only when explicitly mimicking iOS Liquid Glass for a cross-platform consistency reason.
+
+## macOS
+
+### NavigationSplitView detail pane and `@Environment(\.dismiss)`
+
+`@Environment(\.dismiss)` from inside a `NavigationSplitView` *detail* pane does not pop the detail back to "no selection" — it is silently a no-op on macOS / iPad regular width. To clear the detail pane programmatically, write to your `NavigationModel`'s `selectedTodo` (or equivalent selection binding), not `dismiss()`.
+
+This is most often hit when a Detail view detects "underlying object was deleted" and tries to dismiss itself. Write the selection clear into the navigation model instead — it works on both compact (iPhone, where `NavigationSplitView` collapses to `NavigationStack`) and regular widths.
+
+## Multi-platform conditional compilation
+
+Use `#if os(...)` only at the boundary where the shape genuinely differs. Inside SPM packages, declare a single public type whose internals branch on platform; do not duplicate whole types per platform.
+
+```swift
+// ✅ Single type, branch where it matters.
+public struct StatusBadge: View {
+    public enum Size { case compact, prominent }
+    public var body: some View {
+        Label(title, systemImage: systemImage)
+            .font(size == .compact ? .caption : .subheadline)
+            // … padding etc.
+    }
+}
+```
+
+Avoid having `iOSStatusBadge`, `macOSStatusBadge`, `VisionOSStatusBadge` parallel types — that pattern produces drift (different default colors, different padding) that bites later.


### PR DESCRIPTION
## Summary

skill レビュー → PR1-PR4 を回した中で得た 3 つの教訓を \`intent-centric-architecture\` skill に反映。同 skill が他のプロジェクトでも配布される前提なので、IntentTodo 固有の経験ではなく **App Intent 中心設計を採るときの一般的なトラップ** として整理。

## 追記内容

### 1. SwiftData \`@Query\` + \`.onChange(of:)\` 罠 (PR3 P1 巻き戻し由来)

\`references/07-data-and-side-effects.md\` 末尾に新セクション「**SwiftData \`@Query\` and \`.onChange(of:)\` — a frequent foot-gun**」を追加。

> SwiftData's \`@Query\` returns \`[PersistentModel]\`, where each element is a *class*. The array's \`Equatable\` is identity-based — comparing two snapshots checks whether the same objects are at the same indices, not whether their attributes have changed. So when the user toggles \`isCompleted\` or edits a \`title\` in place, \`todoItems\` is "the same" array, \`.onChange(of: todoItems)\` does **not** fire, and the cached \`entities\` go stale.

正しい対処と、本当に 1,000 件規模で問題になった場合の代替策 (SwiftData の struct projection / \`@Query(filter:sort:)\` での絞り込み / pagination) を併記。

### 2. visionOS の Liquid Glass API 制約 (PR2 .glass 戻しの由来)

\`references/08-platform-quirks.md\` (新規) を追加。

- \`GlassButtonStyle\` / \`GlassProminentButtonStyle\` が visionOS 未対応である旨を明示
- \`glassBackgroundEffect()\` (visionOS-only) と \`glassEffect(_:in:)\` (iOS 26+ 横断) と \`GlassEffectContainer\` の関係を整理
- spatial UI の interactivity は \`hoverEffect(.highlight)\` / \`.lift\` を優先

### 3. Liquid Glass HIG の本旨 = 「どこに使わないか」(LG1/LG2 却下経緯)

同じく \`references/08-platform-quirks.md\` に「Liquid Glass philosophy — where to apply, where to refuse」セクションを追加。

> Skill-based reviewers (including the \`swiftui-liquid-glass\` skill) tend to suggest "you should add \`.glassEffect\` here too" wherever a \`.background(color.opacity(...))\` chip exists. **Resist.**

content layer (badge / chip / card) と navigation layer (toolbar / sidebar / ornament / floating) の境界を表で整理。「reduce existing glass usage is also a refactor」(削るのも refactor) という観点も追記。

## その他

\`08-platform-quirks.md\` に同梱:

- **watchOS の CPU 制約**: 二重 filter / \`Date()\` 都度生成は "nice to have" ではなく "shipping requirement"
- **macOS \`NavigationSplitView\` detail-pane の \`dismiss()\` no-op**: \`navigationModel.selectedTodo = nil\` で代替する
- **多プラットフォーム \`StatusBadge\` 一本化**: \`iOSStatusBadge\` / \`VisionOSStatusBadge\` を並立させない指針

\`SKILL.md\` の Anti-patterns に 3 行追加 + Notes に「skill レビューを candidate list として扱う姿勢」を追記。

## 変更ファイル

| ファイル | 変更 |
|---|---|
| \`SKILL.md\` | references リスト更新、Anti-patterns +3 行、Notes +1 段落 |
| \`references/07-data-and-side-effects.md\` | SwiftData @Query foot-gun セクション追加 (+39 行) |
| \`references/08-platform-quirks.md\` | 新規 (visionOS / Liquid Glass / watchOS / macOS / 多プラットフォーム) |

3 files changed, 131 insertions(+).

## なぜ skill 本体に追記するか

これらは IntentTodo 固有の問題ではなく、**App Intent 中心設計を採用したマルチプラットフォーム Apple アプリで普遍的にハマるパターン**。skill 配布物 (\`https://github.com/touyou/IntentTodo\` の plugin) が他のプロジェクトに展開された時に、同じ罠を踏む確率を下げる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)